### PR TITLE
FIX: getFilePath not implemented

### DIFF
--- a/lib/news/news.php
+++ b/lib/news/news.php
@@ -94,4 +94,8 @@ class NewsTable extends DataManager
 
         return $USER->GetID();
     }
+
+    public static function getFilePath() {
+        return __FILE__;
+    }
 }


### PR DESCRIPTION
Битрикс на версии 14.5.0 ругался на отсутствие метода getFilePath в файле lib/news/news.php
